### PR TITLE
Ignoring database arguments in connection string

### DIFF
--- a/core/db/sqlite/manager.go
+++ b/core/db/sqlite/manager.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 )
 
@@ -17,9 +18,14 @@ func NewManager(url string) *manager {
 
 // Create sqlite database file in the passed URL
 func (a *manager) Create() error {
-	_, err := os.Create(a.url)
+	u, err := url.Parse(a.url)
 	if err != nil {
-		return fmt.Errorf("error creating database: %w", err)
+		return fmt.Errorf("error parsing database URL: %w", err)
+	}
+
+	_, err = os.Create(u.Path)
+	if err != nil {
+		return fmt.Errorf("error creating database file %s: %w", u.Path, err)
 	}
 
 	return nil
@@ -27,7 +33,12 @@ func (a *manager) Create() error {
 
 // Drop sqlite database by removing the database file.
 func (a *manager) Drop() error {
-	err := os.Remove(a.url)
+	u, err := url.Parse(a.url)
+	if err != nil {
+		return fmt.Errorf("error parsing database URL: %w", err)
+	}
+
+	err = os.Remove(u.Path)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("error dropping database: %w", err)
 	}

--- a/core/db/sqlite/manager_test.go
+++ b/core/db/sqlite/manager_test.go
@@ -1,0 +1,56 @@
+package sqlite_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/leapkit/leapkit/core/db/sqlite"
+)
+
+func TestCreate(t *testing.T) {
+	f := t.TempDir()
+	wd, _ := os.Getwd()
+
+	os.Chdir(f)
+	defer os.Chdir(wd)
+
+	m := sqlite.NewManager("database.db?_fk=true")
+	err := m.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = os.Stat("database.db")
+	if err != nil {
+		t.Fatal("Did not create database.db", err)
+	}
+
+	_, err = os.Stat("database.db?_fk=true")
+	if err == nil {
+		t.Fatal("Created database.db?_fk=true", err)
+	}
+}
+
+func TestDrop(t *testing.T) {
+	f := t.TempDir()
+	wd, _ := os.Getwd()
+
+	os.Chdir(f)
+	defer os.Chdir(wd)
+
+	m := sqlite.NewManager("database.db?_fk=true")
+	err := m.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = m.Drop()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = os.Stat("database.db")
+	if err == nil {
+		t.Fatal("Did not drop database.db", err)
+	}
+}


### PR DESCRIPTION
Ignoring database arguments in connection string when creating and droping the database. This is a useful technique to set things such as _busy_timeout or others.