### PR TITLE
Allow creating actions in root

### DIFF
--- a/kit/generate.go
+++ b/kit/generate.go
@@ -10,7 +10,10 @@ import (
 func generate(args []string) error {
 	if len(args) < 2 {
 		fmt.Println("Usage: generate <generator_name>")
-
+		fmt.Println("Available commands:")
+		fmt.Println("  - migration [name]")
+		fmt.Println("  - action [action|folder/action]")
+		fmt.Println("")
 		return nil
 	}
 
@@ -32,7 +35,7 @@ func generate(args []string) error {
 		}
 	case "action":
 		usage := func() error {
-			fmt.Println("Usage: generate action <folder/action>")
+			fmt.Println("Usage: generate action [action|folder/action]")
 			return nil
 		}
 		if len(args) < 3 {

--- a/kit/generate.go
+++ b/kit/generate.go
@@ -44,10 +44,6 @@ func generate(args []string) error {
 		}
 
 		path := strings.Split(args[2], "/")
-		if len(path) < 2 {
-			return usage()
-		}
-
 		err := gen.New(gen.Params{
 			Kind: "action",
 			Path: path,

--- a/kit/generate/actions/generate.go
+++ b/kit/generate/actions/generate.go
@@ -22,7 +22,7 @@ func Template() string {
 	return templateFile
 }
 
-func generate(f instace) error {
+func generate(f instance) error {
 	// Create the folder
 	if err := os.MkdirAll(filepath.Join(actionsFolder, f.folder), 0755); err != nil {
 		return fmt.Errorf("error creating folder: %w", err)

--- a/kit/generate/actions/instance.go
+++ b/kit/generate/actions/instance.go
@@ -6,29 +6,39 @@ import (
 	"path/filepath"
 )
 
-type instace struct {
+type instance struct {
 	pckg     string
 	folder   string
 	fileName string
 }
 
-func New(path []string) instace {
+func New(path []string) instance {
+	var pckg string = ActionsFolder()
 	fileName := path[len(path)-1] // The last element is the file name
-	folder := path[:len(path)-1]  // The folder is the path without the file name
-	pckg := folder[len(folder)-1] // The package is the last element of the folder
 
-	return instace{
+	if len(path) == 1 {
+		return instance{
+			pckg:     pckg,
+			folder:   "",
+			fileName: fileName,
+		}
+	}
+
+	folderSlice := path[:len(path)-1]             // The folder is the path without the file name
+	pckg = folderSlice[len(folderSlice)-1]        // The package is the last element of the folder
+	folder := filepath.Join(folderSlice...) + "/" // Join folder elements with "/" and append "/"
+	return instance{
 		pckg:     pckg,
-		folder:   filepath.Join(folder...),
+		folder:   folder,
 		fileName: fileName,
 	}
 }
 
-func (f instace) Generate() error {
+func (f instance) Generate() error {
 	return generate(f)
 }
 
-func (f instace) create(ext string) error {
+func (f instance) create(ext string) error {
 	file, err := os.Create(filepath.Join(ActionsFolder(), f.folder, f.fileName+ext))
 	if err != nil {
 		return err

--- a/kit/generate/actions/instance.go
+++ b/kit/generate/actions/instance.go
@@ -24,12 +24,11 @@ func New(path []string) instance {
 		}
 	}
 
-	folderSlice := path[:len(path)-1]             // The folder is the path without the file name
-	pckg = folderSlice[len(folderSlice)-1]        // The package is the last element of the folder
-	folder := filepath.Join(folderSlice...) + "/" // Join folder elements with "/" and append "/"
+	folder := path[:len(path)-1] // The folder is the path without the file name
+	pckg = folder[len(folder)-1] // The package is the last element of the folder
 	return instance{
 		pckg:     pckg,
-		folder:   folder,
+		folder:   filepath.Join(folder...) + "/", // Join folder elements with "/" and append "/"
 		fileName: fileName,
 	}
 }

--- a/kit/generate/actions/templ.txt
+++ b/kit/generate/actions/templ.txt
@@ -9,7 +9,7 @@ import (
 func Name(w http.ResponseWriter, r *http.Request) {
 	rw := render.FromCtx(r.Context())
 
-	if err := rw.Render("{{.Folder}}/{{.FileName}}.html"); err != nil {
+	if err := rw.Render("{{.Folder}}{{.FileName}}.html"); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/kit/generate_test.go
+++ b/kit/generate_test.go
@@ -61,7 +61,7 @@ func TestGenerateAction(t *testing.T) {
 		{
 			name:       "No action name",
 			actionName: "",
-			output:     "Usage: generate action <folder/action>\n",
+			output:     "Usage: generate action [action|folder/action]\n",
 		},
 		{
 			name:       "r",

--- a/kit/generate_test.go
+++ b/kit/generate_test.go
@@ -70,8 +70,8 @@ func TestGenerateAction(t *testing.T) {
 		},
 		{
 			name:       "withouth slash",
-			actionName: "action",
-			output:     "Usage: generate action <folder/action>\n",
+			actionName: "activity",
+			output:     "Action files created successfully✅\n",
 		},
 		{
 			name:       "two slashes",
@@ -90,6 +90,14 @@ func TestGenerateAction(t *testing.T) {
 
 			//Remove the files created in the tests
 			if err := os.RemoveAll("internal/some"); err != nil {
+				t.Fatalf("error removing files: %v", err)
+			}
+
+			if err := os.RemoveAll("internal/activity.go"); err != nil {
+				t.Fatalf("error removing files: %v", err)
+			}
+
+			if err := os.RemoveAll("internal/activity.html"); err != nil {
 				t.Fatalf("error removing files: %v", err)
 			}
 


### PR DESCRIPTION
## Description ##
This PR allows creating actions in the root by using `kit gen action name`.  The action files will be created in the internal package. 

## Note
Took advantage to fix a typo in the `instance` struct
