### PR TITLE
Fix typo in migration.sql.tmpl file

### DIFF
--- a/kit/generate/migration.sql.tmpl
+++ b/kit/generate/migration.sql.tmpl
@@ -1,1 +1,1 @@
-`-- {{.Timestamp}} - {{.Name }} migration`
+-- {{.Timestamp}} - {{.Name }} migration


### PR DESCRIPTION
## Description ##
This pr fixes a typo in the migration template that sql recognizes as a syntax error