### PR TITLE
feat: assets as server option

### DIFF
--- a/template/internal/app.go
+++ b/template/internal/app.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/leapkit/leapkit/core/assets"
 	"github.com/leapkit/leapkit/core/db"
 	"github.com/leapkit/leapkit/core/render"
 	"github.com/leapkit/leapkit/core/server"
@@ -44,24 +43,17 @@ func New() Server {
 			cmp.Or(os.Getenv("SESSION_SECRET"), "d720c059-9664-4980-8169-1158e167ae57"),
 			cmp.Or(os.Getenv("SESSION_NAME"), "leapkit_session"),
 		),
+		server.WithAssets(public.Files),
 	)
 
-	assetsManager := assets.NewManager(public.Files)
 	r.Use(render.Middleware(
 		render.TemplateFS(tmpls, "internal"),
 
 		render.WithDefaultLayout("layout.html"),
 		render.WithHelpers(render.AllHelpers),
-		render.WithHelpers(map[string]any{
-			"assetPath": assetsManager.PathFor,
-		}),
 	))
 
 	r.HandleFunc("GET /{$}", home.Index)
-
-	// Mounting the assets manager at the end of the routes
-	// so that it can serve the public assets.
-	r.HandleFunc(assetsManager.HandlerPattern(), assetsManager.HandlerFn)
 
 	return r
 }


### PR DESCRIPTION
This PR introduces the new `server.WithAssets` option which loads the assets into the app.

This option receives the embedded file system that will be used to serve the assets. This option also sets the `assetPath` function into the context valuer, if any, so it can be used in other components, for instance, render helpers.