### PR TITLE
fix(assets): fixing assets route mapping

### DIFF
--- a/core/assets/handler.go
+++ b/core/assets/handler.go
@@ -13,8 +13,8 @@ func (m *manager) HandlerPattern() string {
 	return m.servingPath
 }
 
-func (m *manager) HandlerFn(w http.ResponseWriter, r *http.Request) {
-	http.ServeFileFS(w, r, m, strings.TrimPrefix(r.URL.Path, m.handlerPrefix()))
+func (m *manager) Handler() http.Handler {
+	return http.StripPrefix(m.servingPath, http.FileServerFS(m))
 }
 
 func (m *manager) Open(name string) (file fs.File, err error) {
@@ -34,9 +34,9 @@ func (m *manager) Open(name string) (file fs.File, err error) {
 		fn = m.folder.Open
 	}
 
-	name = strings.TrimPrefix(name, m.handlerPrefix())
-
+	name = strings.TrimPrefix(name, m.servingPath)
 	file, err = fn(name)
+
 	return file, err
 }
 
@@ -47,8 +47,4 @@ func (m *manager) ReadFile(name string) ([]byte, error) {
 	}
 
 	return io.ReadAll(x)
-}
-
-func (m *manager) handlerPrefix() string {
-	return strings.TrimSuffix(m.servingPath, "*")
 }

--- a/core/assets/manager.go
+++ b/core/assets/manager.go
@@ -32,7 +32,7 @@ func NewManager(embedded fs.FS) *manager {
 
 		inputFolder:  "internal/assets",
 		outputFolder: "public",
-		servingPath:  "/public/*",
+		servingPath:  "/public/",
 
 		fileToHash: map[string]string{},
 		HashToFile: map[string]string{},

--- a/core/server/option.go
+++ b/core/server/option.go
@@ -43,7 +43,6 @@ func WithSession(secret, name string, options ...session.Option) Option {
 
 func WithAssets(embedded fs.FS) Option {
 	manager := assets.NewManager(embedded)
-
 	return func(m *mux) {
 		m.Use(func(h http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -55,6 +54,6 @@ func WithAssets(embedded fs.FS) Option {
 			})
 		})
 
-		m.HandleFunc(manager.HandlerPattern(), manager.HandlerFn)
+		m.mux.Handle(manager.HandlerPattern(), manager.Handler())
 	}
 }

--- a/core/server/option.go
+++ b/core/server/option.go
@@ -54,6 +54,6 @@ func WithAssets(embedded fs.FS) Option {
 			})
 		})
 
-		m.mux.Handle(manager.HandlerPattern(), manager.Handler())
+		m.Folder(manager.HandlerPattern(), manager)
 	}
 }

--- a/core/server/router.go
+++ b/core/server/router.go
@@ -79,8 +79,8 @@ func (rg *router) HandleFunc(pattern string, handler http.HandlerFunc) {
 // Folder allows to serve static files from a directory
 func (rg *router) Folder(prefix string, fs fs.FS) {
 	rg.mux.Handle(
-		fmt.Sprintf("GET %s/*", path.Join(rg.prefix, prefix)),
-		http.StripPrefix(prefix, http.FileServer(http.FS(fs))),
+		fmt.Sprintf("GET %s", path.Join(rg.prefix, prefix)),
+		http.StripPrefix(prefix, http.FileServerFS(fs)),
 	)
 }
 

--- a/core/server/router.go
+++ b/core/server/router.go
@@ -79,7 +79,7 @@ func (rg *router) HandleFunc(pattern string, handler http.HandlerFunc) {
 // Folder allows to serve static files from a directory
 func (rg *router) Folder(prefix string, fs fs.FS) {
 	rg.mux.Handle(
-		fmt.Sprintf("GET %s", path.Join(rg.prefix, prefix)),
+		fmt.Sprintf("GET %s/", path.Join(rg.prefix, prefix)),
 		http.StripPrefix(prefix, http.FileServerFS(fs)),
 	)
 }


### PR DESCRIPTION
I made the following changes in this PR:

- I removed the asterisk from the _assetsManager.servingPath_ and instead used the prefix `/public/` to serve the assets.
- I updated the `WithAssets` server option to register the asset handler by using the `router.Folder` method.
- I removed the asterisk from the pattern mapped into the `router.Folder` method because the ServerMux doesn't support this character within patterns.