### PR TITLE
feat: adding custom error pages

### DIFF
--- a/core/server/error.go
+++ b/core/server/error.go
@@ -12,10 +12,10 @@ func Error(w http.ResponseWriter, err error, HTTPStatus int) {
 	http.Error(w, err.Error(), HTTPStatus)
 }
 
-type errorHandler func(w http.ResponseWriter, r *http.Request, err error)
+type errorHandlerFn func(w http.ResponseWriter, r *http.Request, err error)
 
 var (
-	errorHandlerMap = map[int]errorHandler{
+	errorHandlerMap = map[int]errorHandlerFn{
 		http.StatusNotFound: func(w http.ResponseWriter, r *http.Request, err error) {
 			w.Write([]byte("404 page not found"))
 		},
@@ -26,7 +26,3 @@ var (
 		},
 	}
 )
-
-func RegisterErrorHandler(status int, fn errorHandler) {
-	errorHandlerMap[status] = fn
-}

--- a/core/server/error.go
+++ b/core/server/error.go
@@ -27,6 +27,6 @@ var (
 	}
 )
 
-func CustomErrorPage(status int, fn errorHandler) {
+func RegisterErrorHandler(status int, fn errorHandler) {
 	errorHandlerMap[status] = fn
 }

--- a/core/server/error.go
+++ b/core/server/error.go
@@ -11,3 +11,22 @@ func Error(w http.ResponseWriter, err error, HTTPStatus int) {
 
 	http.Error(w, err.Error(), HTTPStatus)
 }
+
+type errorHandler func(w http.ResponseWriter, r *http.Request, err error)
+
+var (
+	errorHandlerMap = map[int]errorHandler{
+		http.StatusNotFound: func(w http.ResponseWriter, r *http.Request, err error) {
+			w.Write([]byte("404 page not found"))
+		},
+
+		http.StatusInternalServerError: func(w http.ResponseWriter, r *http.Request, err error) {
+			slog.Error(err.Error())
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		},
+	}
+)
+
+func CustomErrorPage(status int, fn errorHandler) {
+	errorHandlerMap[status] = fn
+}

--- a/core/server/middleware.go
+++ b/core/server/middleware.go
@@ -94,7 +94,8 @@ func recoverer(next http.Handler) http.Handler {
 					os.Stderr.Write(debug.Stack())
 				}
 
-				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				w.WriteHeader(http.StatusInternalServerError)
+				errorHandlerMap[http.StatusInternalServerError](w, r, fmt.Errorf("%s", err))
 			}
 		}()
 

--- a/core/server/mux.go
+++ b/core/server/mux.go
@@ -10,9 +10,8 @@ var defaultCatchAllHandler http.Handler = http.HandlerFunc(func(w http.ResponseW
 		return
 	}
 
-	// TODO: Support custom 404 or have a default one.
 	w.WriteHeader(http.StatusNotFound)
-	w.Write([]byte("404 page not found"))
+	errorHandlerMap[http.StatusNotFound](w, r, nil)
 })
 
 // Rood routeGroup is a group of routes with a common prefix and middleware

--- a/core/server/option.go
+++ b/core/server/option.go
@@ -57,3 +57,9 @@ func WithAssets(embedded fs.FS) Option {
 		m.Folder(manager.HandlerPattern(), manager)
 	}
 }
+
+func WithErrorHandler(status int, errorHandlerFn errorHandlerFn) Option {
+	return func(m *mux) {
+		errorHandlerMap[status] = errorHandlerFn
+	}
+}

--- a/docs/core/assets.md
+++ b/docs/core/assets.md
@@ -11,27 +11,23 @@ This handler is capable of a few things that are useful for web development:
 
 ## Usage
 
-The usage of the assets package is centered around the Assets manager instance.
+To set our assets into our Leapkit app, we need to use the `WithAssets` server option. It receives an FS parameter that will help locate template files to be served.
 
 ```go
 
-// Assets is the manager for the public assets
-// it allows to watch for changes and reload the assets
-// when changes are made.
-Assets = assets.NewManager(public.Files)
-...
-// Register the assets handler
-// This handler will serve the files from the public folder
-...
-	r.HandleFunc(Assets.HandlerPattern(), Assets.HandlerFn)
-}
+//go:embed templates/**/*.html
+var templatesFS embed.FS
+
+r := server.New(
+	server.WithAssets(templatesFS),
+)
 ```
 
 ## Fingerprinting Helper
-The assets manager provides a PathFor helper that can be used in your templates to use the fingerprinted version of an asset.
+The `server.WithAssets` option also setus the `assetsPath` helper that can be used in your templates to use the fingerprinted version of an asset.
 
 ```html
-<link rel="stylesheet" href="<%= assets.PathFor("/css/app.css") %>">
+<link rel="stylesheet" href="<%= assetPath(`/css/app.css`) %>">
 // will output something like
 <link rel="stylesheet" href="/css/app-cafe123ff22112eedd.css">
 ```

--- a/docs/core/routing.md
+++ b/docs/core/routing.md
@@ -69,6 +69,27 @@ WithPort allows to specify the port of the server. By default its `3000`.
 ### WithSession
 WithSession allows to set a new session into the server. [Read more](/core/session.html).
 
+### WithAssets
+WithAssets allows to set assets into the server. [Read more](/core/assets.html).
+
+### WithErrorHandler
+WithErrorHandler allows you to set your custom 404 or 500 pages
+
+```go
+r := server.New(
+	server.WithErrorHandler(http.StatusNotFound, notFoundErrorHandler),
+	server.WithErrorHandler(http.StatusInternalServerError, notFoundErrorHandler),
+)
+// ...
+func notFoundErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
+	w.Write([]byte("Oops! We couldn't find the page you were looking for"))
+}
+
+func internalServerErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
+	w.Write([]byte("There were some technical issues while processing your request"))
+}
+```
+
 ## Middleware
 The Router returned by the `server.New` function has a `Use` method that allows you to add middleware to the server.
 
@@ -82,13 +103,12 @@ func headerMW(next http.Handler) http.Handler {
 	})
 }
 
-...
+// ...
 	s.Use(headerMW)
 	s.HandleFunc("/hello", helloHandler)
 
 	fmt.Println("Server started at", s.Addr())
-...
-}
+// ...
 ```
 
 ## Grouping Routes


### PR DESCRIPTION
This MR allows to set custom error pages.

The error pages can now be added by calling the new `RegisterErrorHandler` function, which takes the error status code and the error handler function to be executed when the response status matches the set status code.

```go
server.RegisterErrorHandler(http.StatusNotFound, func(w http.ResponseWriter, r *http.Request, _ error) {
	rw := render.FromCtx(r.Context())
	if err := rw.Render("errors/404.html"); err != nil {
		http.Error(w, err.Error(), http.StatusInternalServerError)
	}
})

server.RegisterErrorHandler(http.StatusInternalServerError, func(w http.ResponseWriter, r *http.Request, err error) {
	rw := render.FromCtx(r.Context())
	rw.Set("error", err)
	if rErr := rw.Render("errors/505.html"); rErr != nil {
		http.Error(w, rErr.Error(), http.StatusInternalServerError)
	}
})
```