### PR TITLE
feat: adding custom error pages for Leapkit

### DIFF
--- a/core/server/router.go
+++ b/core/server/router.go
@@ -70,6 +70,8 @@ func (rg *router) Handle(pattern string, handler http.Handler) {
 	// When this route is set we mark the rootSet as true
 	rg.rootSet = rg.rootSet || (pattern == "/")
 
+	handler = recoverer(handler)
+
 	// Wrapping with the middleware
 	for i := len(rg.middleware) - 1; i >= 0; i-- {
 		handler = rg.middleware[i](handler)

--- a/template/internal/app.go
+++ b/template/internal/app.go
@@ -9,6 +9,7 @@ import (
 	"github.com/leapkit/leapkit/core/db"
 	"github.com/leapkit/leapkit/core/render"
 	"github.com/leapkit/leapkit/core/server"
+	"github.com/leapkit/leapkit/template/internal/errors"
 	"github.com/leapkit/leapkit/template/internal/home"
 	"github.com/leapkit/leapkit/template/public"
 )
@@ -44,11 +45,12 @@ func New() Server {
 			cmp.Or(os.Getenv("SESSION_NAME"), "leapkit_session"),
 		),
 		server.WithAssets(public.Files),
+		server.WithErrorHandler(http.StatusNotFound, errors.NotFoundErrorHandler),
+		server.WithErrorHandler(http.StatusInternalServerError, errors.InternalServerErrorHandler),
 	)
 
 	r.Use(render.Middleware(
 		render.TemplateFS(tmpls, "internal"),
-
 		render.WithDefaultLayout("layout.html"),
 	))
 

--- a/template/internal/errors/error_page.html
+++ b/template/internal/errors/error_page.html
@@ -1,0 +1,10 @@
+<div class="flex flex-col justify-center items-center text-center h-full">
+    <div class="text-9xl font-bold mb-12"><%= statusCode %></div>
+    <h2 class="font-bold text-3xl mb-4"><%= title %></h2>
+    <p class="tracking-wide text-gray-800 max-w-lg mb-9 h-12"><%= description %></p>
+    <a href="/" class="bg-black text-white rounded-full p-4 inline-flex justify-center items-center hover:bg-gray-800 transition-colors ease-in-out duration-150">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+            <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 19.5-15-15m0 0v11.25m0-11.25h11.25" />
+        </svg>
+    </a>
+</div>

--- a/template/internal/errors/errors.go
+++ b/template/internal/errors/errors.go
@@ -1,0 +1,34 @@
+package errors
+
+import (
+	"net/http"
+
+	"github.com/leapkit/leapkit/core/render"
+	"github.com/leapkit/leapkit/core/server"
+)
+
+func NotFoundErrorHandler(w http.ResponseWriter, r *http.Request, _ error) {
+	renderErrorPage(w, r,
+		http.StatusNotFound,
+		"Something is wrong",
+		"The page you are looking for was moved, removed, renamed or might never existed!",
+	)
+}
+
+func InternalServerErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
+	renderErrorPage(w, r,
+		http.StatusInternalServerError,
+		"Sorry, unexpected error",
+		"We are working on fixing the problem, Be back soon",
+	)
+}
+
+func renderErrorPage(w http.ResponseWriter, r *http.Request, statusCode int, title, description string) {
+	rw := render.FromCtx(r.Context())
+	rw.Set("statusCode", statusCode)
+	rw.Set("title", title)
+	rw.Set("description", description)
+	if err := rw.Render("errors/error_page.html"); err != nil {
+		server.Error(w, err, http.StatusInternalServerError)
+	}
+}


### PR DESCRIPTION
Adding a default error pages for 404 and 500 status codes:

<img width="854" alt="image" src="https://github.com/user-attachments/assets/e650f549-04de-47a2-b661-cf6a36d524a8">
