### PR TITLE
change: listening by default to .go, not assets files

### DIFF
--- a/kit/serve.go
+++ b/kit/serve.go
@@ -11,12 +11,18 @@ import (
 var watchExtensions string
 
 func init() {
-	flag.StringVar(&watchExtensions, "watch.extensions", ".go,.css,.js", "comma separated extensions to watch for recompile")
+	flag.StringVar(&watchExtensions, "watch.extensions", ".go", "comma separated extensions to watch for recompile")
 }
 
 func serve(_ []string) error {
-	exts := rebuilder.WatchExtension(strings.Split(watchExtensions, ",")...)
-	err := rebuilder.Start("cmd/app/main.go", exts)
+	err := rebuilder.Start(
+		"cmd/app/main.go",
+
+		// expecifying the extensions to watch for
+		rebuilder.WatchExtension(
+			strings.Split(watchExtensions, ",")...,
+		),
+	)
 	if err != nil {
 		fmt.Println("[error] starting the server:", err)
 	}


### PR DESCRIPTION
Given we will defer the recompiling of the CSS to external tools (p.e. TailwindCLI) and that in development we serve files from the FS we don't need to listen to changes in assets.