### PR TITLE
task: removing 'public' folder

### DIFF
--- a/core/assets/fingerprint_test.go
+++ b/core/assets/fingerprint_test.go
@@ -9,40 +9,42 @@ import (
 )
 
 func TestFingerprint(t *testing.T) {
+	assetsPath := "/files/"
 	m := assets.NewManager(fstest.MapFS{
-		"main.js":       {Data: []byte("AAA")},
-		"other/main.js": {Data: []byte("AAA")},
-	})
+		"main.js":        {Data: []byte("AAA")},
+		"other/main.js":  {Data: []byte("AAA")},
+		"custom/main.go": {Data: []byte("AAAA")},
+	}, assetsPath)
 
 	t.Run("is deterministic", func(t *testing.T) {
-		a, _ := m.PathFor("public/main.js")
-		b, _ := m.PathFor("public/main.js")
+		a, _ := m.PathFor("files/main.js")
+		b, _ := m.PathFor("files/main.js")
 		if a != b {
 			t.Errorf("Expected %s to equal %s", a, b)
 		}
 
-		if !strings.Contains(a, "/public/") {
-			t.Errorf("Expected %s to have /public/ prefix", a)
+		if !strings.Contains(a, assetsPath) {
+			t.Errorf("Expected %s to have %s prefix", a, assetsPath)
 		}
 
-		a, _ = m.PathFor("public/other/main.js")
-		b, _ = m.PathFor("public/other/main.js")
+		a, _ = m.PathFor("files/other/main.js")
+		b, _ = m.PathFor("files/other/main.js")
 		if a != b {
 			t.Errorf("Expected %s to equal %s", a, b)
 		}
 
-		if !strings.Contains(a, "/public/") {
-			t.Errorf("Expected %s to have /public/ prefix", a)
+		if !strings.Contains(a, assetsPath) {
+			t.Errorf("Expected %s to have %s prefix", a, assetsPath)
 		}
 	})
 
 	t.Run("adds starting slash", func(t *testing.T) {
-		a, err := m.PathFor("public/main.js")
+		a, err := m.PathFor("files/main.js")
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		b, err := m.PathFor("/public/main.js")
+		b, err := m.PathFor("/files/main.js")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -52,11 +54,11 @@ func TestFingerprint(t *testing.T) {
 		}
 	})
 
-	t.Run("adds starting /public", func(t *testing.T) {
+	t.Run("adds starting /files", func(t *testing.T) {
 		a, _ := m.PathFor("main.js")
 		t.Log(a)
-		if !strings.HasPrefix(a, "/public") {
-			t.Errorf("Expected %s to start with /public", a)
+		if !strings.HasPrefix(a, "/files") {
+			t.Errorf("Expected %s to start with /files", a)
 		}
 	})
 
@@ -66,17 +68,17 @@ func TestFingerprint(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if !strings.HasPrefix(a, "/public/main-") {
-			t.Errorf("Expected %s to contain /public/other/main-<hash>", a)
+		if !strings.HasPrefix(a, "/files/main-") {
+			t.Errorf("Expected %s to contain /files/other/main-<hash>", a)
 		}
 
-		b, _ := m.PathFor("public/other/main.js")
+		b, _ := m.PathFor("files/other/main.js")
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if !strings.HasPrefix(b, "/public/other/main-") {
-			t.Errorf("Expected %s to contain /public/other/main-<hash>", b)
+		if !strings.HasPrefix(b, "/files/other/main-") {
+			t.Errorf("Expected %s to contain /files/other/main-<hash>", b)
 		}
 
 		if a == b {
@@ -88,6 +90,100 @@ func TestFingerprint(t *testing.T) {
 		a, err := m.PathFor("foo.js")
 		if err == nil {
 			t.Errorf("File must not exists: %s", a)
+		}
+	})
+
+	t.Run("file does not exist", func(t *testing.T) {
+		a, err := m.PathFor("custom/main.go")
+		if err == nil {
+			t.Errorf("File must not exists: %s", a)
+		}
+	})
+
+	t.Run("manager looks for files in root", func(t *testing.T) {
+		m := assets.NewManager(fstest.MapFS{
+			"main.js":       {Data: []byte("AAA")},
+			"other/main.js": {Data: []byte("AAA")},
+		}, "")
+
+		a, err := m.PathFor("main.js")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !strings.HasPrefix(a, "/") {
+			t.Errorf("Expected %s to start with /", a)
+		}
+
+		b, err := m.PathFor("other/main.js")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !strings.HasPrefix(b, "/") {
+			t.Errorf("Expected %s to start with /", b)
+		}
+	})
+
+	t.Run("PathFor normalize file path", func(t *testing.T) {
+		cases := []struct {
+			servingPath string
+			name        string
+			expected    string
+		}{
+			{"public", "main.js", "/public/main-"},
+			{"public", "/main.js", "/public/main-"},
+			{"public", "public/main.js", "/public/main-"},
+			{"public", "/public/main.js", "/public/main-"},
+			{"public", "/other/main.js", "/public/other/main-"},
+			{"public", "other/main.js", "/public/other/main-"},
+
+			{"/public", "main.js", "/public/main-"},
+			{"/public", "/main.js", "/public/main-"},
+			{"/public", "public/main.js", "/public/main-"},
+			{"/public", "/public/main.js", "/public/main-"},
+			{"/public", "public/other/main.js", "/public/other/main-"},
+			{"/public", "/public/other/main.js", "/public/other/main-"},
+
+			{"/public/", "main.js", "/public/main-"},
+			{"/public/", "/main.js", "/public/main-"},
+			{"/public/", "public/main.js", "/public/main-"},
+			{"/public/", "/public/main.js", "/public/main-"},
+			{"/public/", "public/other/main.js", "/public/other/main-"},
+			{"/public/", "/public/other/main.js", "/public/other/main-"},
+
+			{"public/other", "main.js", "/public/other/main-"},
+			{"public/other", "/main.js", "/public/other/main-"},
+			{"public/other", "public/other/main.js", "/public/other/main-"},
+			{"public/other", "/public/other/main.js", "/public/other/main-"},
+			{"/public/other", "public/other/main.js", "/public/other/main-"},
+			{"/public/other", "/public/other/main.js", "/public/other/main-"},
+
+			{"/public/other", "main.js", "/public/other/main-"},
+			{"/public/other", "/main.js", "/public/other/main-"},
+			{"/public/other", "public/other/main.js", "/public/other/main-"},
+			{"/public/other", "/public/other/main.js", "/public/other/main-"},
+
+			{"/public/other/", "main.js", "/public/other/main-"},
+			{"/public/other/", "/main.js", "/public/other/main-"},
+			{"/public/other/", "public/other/main.js", "/public/other/main-"},
+			{"/public/other/", "/public/other/main.js", "/public/other/main-"},
+		}
+
+		for i, c := range cases {
+			manager := assets.NewManager(fstest.MapFS{
+				"main.js":       {Data: []byte("AAA")},
+				"other/main.js": {Data: []byte("AAA")},
+			}, c.servingPath)
+
+			result, err := manager.PathFor(c.name)
+			if err != nil {
+				t.Errorf("%d, Expected no error, got %s", i, err)
+			}
+
+			if !strings.HasPrefix(result, c.expected) {
+				t.Errorf("%d, Expected %s to start with /public/", i, result)
+			}
 		}
 	})
 }

--- a/core/assets/handler.go
+++ b/core/assets/handler.go
@@ -3,7 +3,6 @@ package assets
 import (
 	"io"
 	"io/fs"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,31 +12,20 @@ func (m *manager) HandlerPattern() string {
 	return m.servingPath
 }
 
-func (m *manager) Handler() http.Handler {
-	return http.StripPrefix(m.servingPath, http.FileServerFS(m))
-}
-
-func (m *manager) Open(name string) (file fs.File, err error) {
+func (m *manager) Open(name string) (fs.File, error) {
 	ext := filepath.Ext(name)
 	if ext == ".go" {
 		return nil, os.ErrNotExist
 	}
 
 	// Converting hashed into original file name
-	smp := m.HashToFile[name]
-	if smp != "" {
-		name = smp
-	}
-
-	fn := m.embedded.Open
-	if env := os.Getenv("GO_ENV"); env == "development" {
-		fn = m.folder.Open
+	if original, ok := m.HashToFile[name]; ok {
+		name = original
 	}
 
 	name = strings.TrimPrefix(name, m.servingPath)
-	file, err = fn(name)
 
-	return file, err
+	return m.embedded.Open(name)
 }
 
 func (m *manager) ReadFile(name string) ([]byte, error) {
@@ -45,6 +33,7 @@ func (m *manager) ReadFile(name string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer x.Close()
 
 	return io.ReadAll(x)
 }

--- a/core/assets/handler.go
+++ b/core/assets/handler.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (m *manager) HandlerPattern() string {
+	if m.servingPath == "/" {
+		return ""
+	}
+
 	return m.servingPath
 }
 

--- a/core/assets/manager.go
+++ b/core/assets/manager.go
@@ -2,16 +2,13 @@ package assets
 
 import (
 	"io/fs"
-	"os"
+	"path"
+	"strings"
 	"sync"
 )
 
 type manager struct {
 	embedded fs.FS
-	folder   fs.FS
-
-	outputFolder string
-	inputFolder  string
 
 	servingPath string
 
@@ -20,21 +17,25 @@ type manager struct {
 	HashToFile map[string]string
 }
 
-// NewManager returns a new manager that wraps the given embed.FS and the input and output folders.
-func NewManager(embedded fs.FS) *manager {
-	// TODO: options to change:
-	// - input
-	// - output.
-	// - serving path.
+// NewManager returns a new manager that wraps the given fs.FS.
+func NewManager(embedded fs.FS, servingPath string) *manager {
+	servingPath = path.Clean(servingPath)
+	if servingPath == "." {
+		servingPath = "/"
+	}
+
+	if !strings.HasPrefix(servingPath, "/") {
+		servingPath = "/" + servingPath
+	}
+
+	if !strings.HasSuffix(servingPath, "/") {
+		servingPath += "/"
+	}
+
 	return &manager{
-		embedded: embedded,
-		folder:   os.DirFS("public"),
-
-		inputFolder:  "internal/assets",
-		outputFolder: "public",
-		servingPath:  "/public/",
-
-		fileToHash: map[string]string{},
-		HashToFile: map[string]string{},
+		embedded:    embedded,
+		servingPath: servingPath,
+		fileToHash:  map[string]string{},
+		HashToFile:  map[string]string{},
 	}
 }

--- a/core/server/option.go
+++ b/core/server/option.go
@@ -41,8 +41,8 @@ func WithSession(secret, name string, options ...session.Option) Option {
 	}
 }
 
-func WithAssets(embedded fs.FS) Option {
-	manager := assets.NewManager(embedded)
+func WithAssets(embedded fs.FS, servingPath string) Option {
+	manager := assets.NewManager(embedded, servingPath)
 	return func(m *mux) {
 		m.Use(func(h http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/template/internal/app.go
+++ b/template/internal/app.go
@@ -43,7 +43,8 @@ func New() Server {
 			cmp.Or(os.Getenv("SESSION_SECRET"), "d720c059-9664-4980-8169-1158e167ae57"),
 			cmp.Or(os.Getenv("SESSION_NAME"), "leapkit_session"),
 		),
-		server.WithAssets(assets.Files, "/"),
+
+		server.WithAssets(assets.Files, "/public/"),
 	)
 
 	r.Use(render.Middleware(

--- a/template/internal/app.go
+++ b/template/internal/app.go
@@ -43,23 +43,15 @@ func New() Server {
 			cmp.Or(os.Getenv("SESSION_SECRET"), "d720c059-9664-4980-8169-1158e167ae57"),
 			cmp.Or(os.Getenv("SESSION_NAME"), "leapkit_session"),
 		),
+		server.WithAssets(assets.Files, "/"),
 	)
 
 	r.Use(render.Middleware(
 		render.TemplateFS(tmpls, "internal"),
 		render.WithDefaultLayout("layout.html"),
-
-		// Adding the assetPath helper to use
-		// fingerprinted asset paths in the templates
-		render.WithHelpers(map[string]any{
-			"assetPath": assets.Manager.PathFor,
-		}),
 	))
 
 	r.HandleFunc("GET /{$}", home.Index)
-
-	// Serving the internal/system/assets folder on /public/
-	r.Folder("/public/", assets.Manager)
 
 	return r
 }

--- a/template/internal/system/assets/assets.go
+++ b/template/internal/system/assets/assets.go
@@ -2,14 +2,7 @@ package assets
 
 import (
 	"embed"
-
-	"github.com/leapkit/leapkit/core/assets"
 )
 
-var (
-	//go:embed *
-	files embed.FS
-
-	// Manager for the PathFor helper
-	Manager = assets.NewManager(files)
-)
+//go:embed *
+var Files embed.FS


### PR DESCRIPTION
This PR restores the `server.WithAssets` option. Both the server option and the assets manager now allows custom serving paths.
