### PR TITLE
task(dev): Watch only '.go' extensions by default

### DIFF
--- a/cli/dev/internal/rebuilder/watcher.go
+++ b/cli/dev/internal/rebuilder/watcher.go
@@ -15,7 +15,7 @@ import (
 var watchExtensions string
 
 func init() {
-	pflag.StringVar(&watchExtensions, "watch.extensions", ".go,.css,.js", "comma separated extensions to watch for recompile")
+	pflag.StringVar(&watchExtensions, "watch.extensions", ".go", "Comma-separated list of file extensions to watch for changes and trigger recompilation (e.g. .go,.css,.js).")
 }
 
 type Watcher interface {


### PR DESCRIPTION
This PR makes the dev tool restart processes only when '.go' files are affected (created, modified, or deleted)
To watch more file extensions we can continue using the `--watch.extension` flag

`go tool dev --watch.extensions .go,.css,.js`